### PR TITLE
Add Azure federated credential parameter files

### DIFF
--- a/infra/az-federated-credential-params/branch-main.json
+++ b/infra/az-federated-credential-params/branch-main.json
@@ -1,0 +1,7 @@
+{
+    "name": "branch-main",
+    "issuer": "[https://token.actions.githubusercontent.com](https://token.actions.githubusercontent.com)",
+    "subject": "repo:seerat-sawhney/cst8918-w25-lab12:branch:main",
+    "description": "CST8918 Lab12 - GitHub Actions",
+    "audiences": ["api://AzureADTokenExchange"]
+  }

--- a/infra/az-federated-credential-params/production-deploy.json
+++ b/infra/az-federated-credential-params/production-deploy.json
@@ -1,0 +1,7 @@
+{
+    "name": "production-deploy",
+    "issuer": "[https://token.actions.githubusercontent.com](https://token.actions.githubusercontent.com)",
+    "subject": "repo:seerat-sawhney/cst8918-w25-lab12:environment:production",
+    "description": "CST8918 Lab12 - GitHub Actions",
+    "audiences": ["api://AzureADTokenExchange"]
+  }

--- a/infra/az-federated-credential-params/pull-request.json
+++ b/infra/az-federated-credential-params/pull-request.json
@@ -1,0 +1,7 @@
+{
+    "name": "pull-request",
+    "issuer": "[https://token.actions.githubusercontent.com](https://token.actions.githubusercontent.com)",
+    "subject": "repo:seerat-sawhney/cst8918-w25-lab12:pull_request",
+    "description": "CST8918 Lab12 - GitHub Actions",
+    "audiences": ["api://AzureADTokenExchange"]
+  }


### PR DESCRIPTION
This PR implements part of Step 3 of Lab 12, setting up the configuration files for Azure federated credentials:
 
Added JSON configuration files:
1. production-deploy.json
   - For GitHub Actions in production environment
   - Will be used with contributor (read-write) service principal
 
2. pull-request.json
   - For GitHub Actions pre-merge checks
   - Will be used with reader (read-only) service principal
 
3. branch-main.json
   - For GitHub Actions on main branch events
   - Will be used with reader (read-only) service principal
 
These files will be used to create federated credentials in Azure AD, enabling GitHub Actions to authenticate with Azure securely.