### PR TITLE
Configure federated credential JSON files and add resource group output

### DIFF
--- a/infra/az-federated-credential-params/branch-main.json
+++ b/infra/az-federated-credential-params/branch-main.json
@@ -1,6 +1,6 @@
 {
     "name": "branch-main",
-    "issuer": "[https://token.actions.githubusercontent.com](https://token.actions.githubusercontent.com)",
+    "issuer": "https://token.actions.githubusercontent.com",
     "subject": "repo:seerat-sawhney/cst8918-w25-lab12:branch:main",
     "description": "CST8918 Lab12 - GitHub Actions",
     "audiences": ["api://AzureADTokenExchange"]

--- a/infra/az-federated-credential-params/production-deploy.json
+++ b/infra/az-federated-credential-params/production-deploy.json
@@ -1,6 +1,6 @@
 {
     "name": "production-deploy",
-    "issuer": "[https://token.actions.githubusercontent.com](https://token.actions.githubusercontent.com)",
+    "issuer": "https://token.actions.githubusercontent.com",
     "subject": "repo:seerat-sawhney/cst8918-w25-lab12:environment:production",
     "description": "CST8918 Lab12 - GitHub Actions",
     "audiences": ["api://AzureADTokenExchange"]

--- a/infra/az-federated-credential-params/pull-request.json
+++ b/infra/az-federated-credential-params/pull-request.json
@@ -1,6 +1,6 @@
 {
     "name": "pull-request",
-    "issuer": "[https://token.actions.githubusercontent.com](https://token.actions.githubusercontent.com)",
+    "issuer": "https://token.actions.githubusercontent.com",
     "subject": "repo:seerat-sawhney/cst8918-w25-lab12:pull_request",
     "description": "CST8918 Lab12 - GitHub Actions",
     "audiences": ["api://AzureADTokenExchange"]

--- a/infra/tf-app/main.tf
+++ b/infra/tf-app/main.tf
@@ -2,3 +2,7 @@ resource "azurerm_resource_group" "app" {
   name     = "jose0337-a12-rg"
   location = "canadacentral"
 }
+
+output "resource_group_name" {
+  value = azurerm_resource_group.app.name
+}


### PR DESCRIPTION
This PR completes Step 3 of Lab 12, setting up Azure credentials for GitHub Actions:

1. Created and configured Azure AD applications:
   - jose0337-githubactions-rw (contributor access)
   - jose0337-githubactions-r (reader access)

2. Created service principals and assigned appropriate roles:
   - Contributor role for RW service principal
   - Reader role for R service principal

3. Fixed JSON configuration files and created federated credentials:
   - Production deployment credential (RW)
   - Pull request credential (R)
   - Branch main credential (R)

4. Added resource group name output to app infrastructure

All Azure resources have been created and verified successfully.