### PR TITLE
Fix TFLint issues: Add variables.tf, move outputs to outputs.tf, add …

### DIFF
--- a/infra/tf-app/main.tf
+++ b/infra/tf-app/main.tf
@@ -2,7 +2,3 @@ resource "azurerm_resource_group" "app" {
   name     = "jose0337-a12-rg"
   location = "canadacentral"
 }
-
-output "resource_group_name" {
-  value = azurerm_resource_group.app.name
-}

--- a/infra/tf-app/outputs.tf
+++ b/infra/tf-app/outputs.tf
@@ -1,0 +1,4 @@
+output "resource_group_name" {
+  description = "The name of the resource group created for the application"
+  value       = azurerm_resource_group.app.name
+}

--- a/infra/tf-app/variables.tf
+++ b/infra/tf-app/variables.tf
@@ -1,1 +1,1 @@
-// This file is intentionally empty to follow Terraform standard module structure
+# This file is intentionally empty to follow Terraform standard module structure

--- a/infra/tf-app/variables.tf
+++ b/infra/tf-app/variables.tf
@@ -1,0 +1,1 @@
+// This file is intentionally empty to follow Terraform standard module structure


### PR DESCRIPTION
This PR fixes the TFLint issues by:

1. Adding empty [variables.tf](cci:7://file:///Users/Daniyal/Desktop/Lab12/cst8918-w25-lab12/infra/tf-app/variables.tf:0:0-0:0) file to follow Terraform standard module structure
2. Moving output from [main.tf](cci:7://file:///Users/Daniyal/Desktop/Lab12/cst8918-w25-lab12/infra/tf-app/main.tf:0:0-0:0) to [outputs.tf](cci:7://file:///Users/Daniyal/Desktop/Lab12/cst8918-w25-lab12/infra/tf-app/outputs.tf:0:0-0:0)
3. Adding description to the `resource_group_name` output

These changes address the following TFLint warnings:
- `terraform_standard_module_structure`: Added missing files and moved outputs
- `terraform_documented_outputs`: Added description to output